### PR TITLE
[1] Config File Adjustment and Nav2

### DIFF
--- a/params/main.yaml
+++ b/params/main.yaml
@@ -11,8 +11,9 @@
     estop_timeout: 9.0
     username: "admin"
     password: "qvxkcpdccpp7"
+    hostname: "192.168.50.3"
     start_estop: False
-    preferred_odom_frame: "vision" # pass either odom/vision. This frame will become the parent of body in tf2 tree and will be used in odometry topic. https://dev.bostondynamics.com/docs/concepts/geometry_and_frames.html?highlight=frame#frames-in-the-spot-robot-world for more info.
+    preferred_odom_frame: "odom" # pass either odom/vision. This frame will become the parent of body in tf2 tree and will be used in odometry topic. https://dev.bostondynamics.com/docs/concepts/geometry_and_frames.html?highlight=frame#frames-in-the-spot-robot-world for more info.
       #    async_tasks_rate: 10
     cmd_duration: 0.125 # Increase if spot stutters while walking
     rgb_cameras: True

--- a/params/nav2_params.yaml
+++ b/params/nav2_params.yaml
@@ -156,7 +156,7 @@ local_costmap:
         #z_voxels: 16
         max_obstacle_height: 2.0
         #mark_threshold: 0
-        observation_sources: back frontleft frontright left right #hand
+        observation_sources: back frontleft frontright left right velodyne #hand
         back:
           topic: /depth_registered/back/points
           max_obstacle_height: 0.8
@@ -223,6 +223,17 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 8.0
           obstacle_min_range: 0.0
+        velodyne:
+          topic: /velodyne_points
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.0
+          clearing: True
+          marking: True
+          data_type: "PointCloud2"
+          raytrace_max_range: 8.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 8.0
+          obstacle_min_range: 0.0
       static_layer:
         map_subscribe_transient_local: True
       always_send_full_costmap: True
@@ -254,7 +265,7 @@ global_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: back frontleft frontright left right #hand
+        observation_sources: back frontleft frontright left right velodyne #hand
         back:
           topic: /depth_registered/back/points
           max_obstacle_height: 0.8
@@ -320,6 +331,17 @@ global_costmap:
           raytrace_max_range: 8.0
           raytrace_min_range: 0.0
           obstacle_max_range: 8.0
+        velodyne:
+          topic: /velodyne_points
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.0
+          clearing: True
+          marking: True
+          data_type: "PointCloud2"
+          raytrace_max_range: 8.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 8.0
+          obstacle_min_range: 0.0
       static_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
         map_subscribe_transient_local: True


### PR DESCRIPTION
I added the `/velodyne_points` topic to the Navigation 2 config file. In addition, the newer version of the Spot Robot and Spot Driver require hostname within the config file. On older versions, you can comment this line out. 

Note that this pull request doesn't consider additional concerns, such as false-positives on the ground being labeled as occupied space.